### PR TITLE
Add detection of TTT-End-Round-Music Exploit

### DIFF
--- a/snte/lua/autorun/server/!!!snte_sv.lua
+++ b/snte/lua/autorun/server/!!!snte_sv.lua
@@ -386,7 +386,8 @@ local legit_nets = {
 	"TCBDealerStore",
 	"TCBDealerSpawn",
 	"gMining.registerAchievement",
-	"gPrinters.openUpgrades"
+	"gPrinters.openUpgrades",
+	"SendQueueInfo"
 }
 
 -- Known backdoor nets


### PR DESCRIPTION
The original TTT-End-Round-Music script from 2014 has a net hook that when exploited allows a player to spam text in chat, and by using that same hook, add a URL to the song queue to beaccessed  with sound,PlayURL on all users at the end of a TTT Round without any form of permissions, allowing for a exploiter to grab the IPs of all players on the server, this added that net message to the list of exploitable net messages.